### PR TITLE
Add service configuration for GraphQL data types

### DIFF
--- a/src/RelationSelectFieldsBundle/Resources/config/services.yml
+++ b/src/RelationSelectFieldsBundle/Resources/config/services.yml
@@ -23,3 +23,19 @@ services:
 #            - "@service_id"
 #            - "plain_value"
 #            - "%parameter%"
+
+    #
+    # DATAHUB
+    #
+
+    # The "Many-to-one select" datatype can act as a regular Href in GraphQL
+    pimcore.datahub.graphql.dataobjectquerytypegenerator_datatype_manytoonerelationselect:
+        class: Pimcore\Bundle\DataHubBundle\GraphQL\DataObjectQueryFieldConfigGenerator\Href
+        tags:
+            - { name: pimcore.datahub.graphql.dataobjectquerytypegenerator, id: typegenerator_dataobjectquerydatatype_manyToOneRelationSelect }
+
+    # The "Many-to-many select" datatype can act as a regular Multihref in GraphQL
+    pimcore.datahub.graphql.dataobjectquerytypegenerator_datatype_manytomanyrelationselect:
+        class: Pimcore\Bundle\DataHubBundle\GraphQL\DataObjectQueryFieldConfigGenerator\Multihref
+        tags:
+            - { name: pimcore.datahub.graphql.dataobjectquerytypegenerator, id: typegenerator_dataobjectquerydatatype_manyToManyRelationSelect }


### PR DESCRIPTION
Adds support for DataHub GraphQL schema. 

If not configured, trying to add fields of this type to a graphql query schema leads to the following error:
> Query datatype 'manyToOneRelationSelect' not supported yet


This configures DataHub to process the relation select fields as regular relation fields in the GraphQL configuration (just like the default Pimcore many-to-one and many-to-many relation fields)